### PR TITLE
Fix Fast Execute for OpenGov Proposal Index 0

### DIFF
--- a/src/tools/fast-execute-chopstick-proposal.ts
+++ b/src/tools/fast-execute-chopstick-proposal.ts
@@ -101,11 +101,11 @@ const generateProposal = async (api: ApiPromise, proposalIndex: number) => {
 };
 
 const main = async () => {
-  if (argv["generate-proposal"] && argv["proposal-index"]) {
+  if (argv["generate-proposal"] && "proposal-index" in argv) {
     console.log("--generate-proposal not compatible with --proposal-index");
     return;
   }
-  if (!argv["generate-proposal"] && !argv["proposal-index"]) {
+  if (!argv["generate-proposal"] && !("proposal-index" in argv)) {
     console.log("Missing --generate-proposal or --proposal-index");
     return;
   }


### PR DESCRIPTION
The current code has issues if the Proposal Index is 0.

In that case:

```
  if (!argv["generate-proposal"] && !argv["proposal-index"]) {
    console.log("Missing --generate-proposal or --proposal-index");
    return;
  }
```
The conditional `!argv["proposal-index"]` will return true when `proposal-index` is 0.