### PR TITLE
chore(tools): adds 🛠️ script for clearing the storage previously used by LocalAssets pallet

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
       - name: Check with Prettier
-        run: npx prettier --check --ignore-path .prettierignore '**/*.(yml|js|ts|json)'
+        run: npx prettier --check --ignore-path .prettierignore '**/*.(yml|js|ts)'

--- a/src/lazy-migrations/001-unlock-democracy-funds.ts
+++ b/src/lazy-migrations/001-unlock-democracy-funds.ts
@@ -5,7 +5,7 @@
   This script will continuously call and wait for completion of unlockDemocracyFunds
   extrinsic from pallet moonbeam-lazy-migrations until the migration is completed.
 
-Ex: npx ts-node src/lazy-migrations/001-unlock-democracy-funds.ts \
+Ex: ./node_modules/.bin/ts-node src/lazy-migrations/001-unlock-democracy-funds.ts \
    --url ws://127.0.0.1:34102 \
    --account-priv-key <key> \
 */

--- a/src/lazy-migrations/001-unlock-democracy-funds.ts
+++ b/src/lazy-migrations/001-unlock-democracy-funds.ts
@@ -5,7 +5,7 @@
   This script will continuously call and wait for completion of unlockDemocracyFunds
   extrinsic from pallet moonbeam-lazy-migrations until the migration is completed.
 
-Ex: ./node_modules/.bin/ts-node unlock-democracy-funds.ts \
+Ex: npx ts-node src/lazy-migrations/001-unlock-democracy-funds.ts \
    --url ws://127.0.0.1:34102 \
    --account-priv-key <key> \
 */
@@ -50,7 +50,6 @@ const main = async () => {
   ).toHuman();
   if (migrationCompleted === true) {
     console.log("Democracy locks migration already completed. Exiting...");
-    return;
   } else {
     console.log("Unlocking democracy funds...");
     while (migrationCompleted === false) {

--- a/src/lazy-migrations/002-clear-local-assets-storage.ts
+++ b/src/lazy-migrations/002-clear-local-assets-storage.ts
@@ -1,7 +1,7 @@
 /*
   Clears the unused storage of pallet LocalAssets removed in runtime 2800
 
-Ex: npx ts-node src/lazy-migrations/002-clear-local-assets-storage.ts \
+Ex: ./node_modules/.bin/ts-node src/lazy-migrations/002-clear-local-assets-storage.ts \
    --url ws://localhost:9944 \
    --max-assets 10 \
    --limit 1000 \

--- a/src/lazy-migrations/002-clear-local-assets-storage.ts
+++ b/src/lazy-migrations/002-clear-local-assets-storage.ts
@@ -62,19 +62,26 @@ async function main() {
     const privKey = argv["alith"] ? ALITH_PRIVATE_KEY : argv["account-priv-key"];
     if (privKey) {
       account = keyring.addFromUri(privKey, null, "ethereum");
-      const { nonce: rawNonce, data: balance } = (await api.query.system.account(
-        account.address
-      ));
+      const { nonce: rawNonce, data: balance } = await api.query.system.account(account.address);
       nonce = BigInt(rawNonce.toString());
     }
 
-    const isMigrationCompleted = (await api.query["moonbeamLazyMigrations"].localAssetsMigrationCompleted()).toPrimitive();
+    const isMigrationCompleted = (
+      await api.query["moonbeamLazyMigrations"].localAssetsMigrationCompleted()
+    ).toPrimitive();
     if (isMigrationCompleted) {
-      throw new Error("Migration completed, all keys have been removed!")
+      throw new Error("Migration completed, all keys have been removed!");
     }
 
-    const extrinsicCall = api.tx["moonbeamLazyMigrations"].clearLocalAssetsStorage(max_assets, entries_to_remove)
-    await extrinsicCall.signAndSend(account, { nonce: nonce++ }, monitorSubmittedExtrinsic(api, { id: "migration" }));
+    const extrinsicCall = api.tx["moonbeamLazyMigrations"].clearLocalAssetsStorage(
+      max_assets,
+      entries_to_remove
+    );
+    await extrinsicCall.signAndSend(
+      account,
+      { nonce: nonce++ },
+      monitorSubmittedExtrinsic(api, { id: "migration" })
+    );
   } finally {
     await waitForAllMonitoredExtrinsics();
     await api.disconnect();

--- a/src/lazy-migrations/002-clear-local-assets-storage.ts
+++ b/src/lazy-migrations/002-clear-local-assets-storage.ts
@@ -1,7 +1,7 @@
 /*
   Clears the unused storage of pallet LocalAssets removed in runtime 2800
 
-Ex: ./node_modules/.bin/ts-node-transpile-only src/tools/clear-local-assets-storage.ts \
+Ex: npx ts-node src/lazy-migrations/002-clear-local-assets-storage.ts \
    --url ws://localhost:9944 \
    --max-assets 10 \
    --limit 1000 \
@@ -69,8 +69,6 @@ async function main() {
     }
 
     const isMigrationCompleted = (await api.query["moonbeamLazyMigrations"].localAssetsMigrationCompleted()).toPrimitive();
-    const isMigrationComplete2 = (await api.query.state.localAssetsMigrationCompleted()).toPrimitive();
-    console.log(isMigrationCompleted)
     if (isMigrationCompleted) {
       throw new Error("Migration completed, all keys have been removed!")
     }

--- a/src/libs/helpers/state-manipulator/genesis-parser.ts
+++ b/src/libs/helpers/state-manipulator/genesis-parser.ts
@@ -40,7 +40,9 @@ export interface StateManipulator {
 
   // Will get executed for each line of the state file during the write phase
   // Can decide to remove/keep the original line and also add extra lines
-  processWrite: (line: StateLine) => { action: Action; extraLines?: StateLine[] } | undefined | void;
+  processWrite: (
+    line: StateLine
+  ) => { action: Action; extraLines?: StateLine[] } | undefined | void;
 }
 
 export function encodeStorageKey(module, name) {

--- a/src/tools/auction-info.ts
+++ b/src/tools/auction-info.ts
@@ -4,7 +4,17 @@ import "@polkadot/api-augment";
 import { getApiFor } from "../utils/networks";
 import { getAccountIdentity } from "../utils/monitoring";
 import { BN } from "@polkadot/util";
-import { isBigInt, isBn, isHex, isNumber, isU8a, u8aConcat, u8aToBn, u8aToHex, u8aToU8a } from '@polkadot/util';
+import {
+  isBigInt,
+  isBn,
+  isHex,
+  isNumber,
+  isU8a,
+  u8aConcat,
+  u8aToBn,
+  u8aToHex,
+  u8aToU8a,
+} from "@polkadot/util";
 
 const argv = yargs(process.argv.slice(2))
   .usage("Usage: $0")
@@ -17,128 +27,178 @@ const argv = yargs(process.argv.slice(2))
       demandOption: true,
     },
     para: {
-        type: "number",
-        description: "Para for which a lease exists",
+      type: "number",
+      description: "Para for which a lease exists",
     },
   }).argv;
 
 type AuctionInfo = {
-    duration: Number;
-    lease_period: Number
+  duration: Number;
+  lease_period: Number;
 };
 
-let auctionMap = new Map<BN,AuctionInfo>();
+let auctionMap = new Map<BN, AuctionInfo>();
 
 function addSeconds(date, seconds) {
-    date.setSeconds(date.getSeconds() + seconds);
-    return date;
+  date.setSeconds(date.getSeconds() + seconds);
+  return date;
 }
 
 async function calculateTimestamp(api, futureblock: number) {
+  let currentBlock = (await api.rpc.chain.getHeader()).number.toNumber();
+  let timestamp = (await api.query.timestamp.now()).toNumber();
 
-    let currentBlock = (await api.rpc.chain.getHeader()).number.toNumber();
-    let timestamp = (await api.query.timestamp.now()).toNumber();
+  let currentDate = new Date(timestamp);
 
-    let currentDate = new Date(timestamp);
+  let blockDifference = futureblock - currentBlock;
 
-    let blockDifference = futureblock - currentBlock;
-    
-    let futureDate = addSeconds(currentDate, (blockDifference * 6));
-    return[futureDate.getTime(), futureDate]
+  let futureDate = addSeconds(currentDate, blockDifference * 6);
+  return [futureDate.getTime(), futureDate];
 }
 
 async function calculateCurrentLeasePeriod(api, leasePeriod, leaseOffset) {
-
-    let currentBlock = (await api.rpc.chain.getHeader()).number.toNumber();
-    return (currentBlock - leaseOffset)/leasePeriod;
+  let currentBlock = (await api.rpc.chain.getHeader()).number.toNumber();
+  return (currentBlock - leaseOffset) / leasePeriod;
 }
 
 const main = async () => {
   const api = await getApiFor(argv);
 
   const scheduled = await api.query.scheduler.agenda.entries();
-  
+
   //scheduled.find()
   for (var i in scheduled) {
-    for(var index in scheduled[i][1]) {
-        if(scheduled[i][1][index].isSome) {
-            let call;
-            if (scheduled[i][1][index].unwrap().call.isLookup) {
-                let lookup = scheduled[i][1][index].unwrap().call.asLookup;
-                let callOption =  await api.query.preimage.preimageFor([lookup.hash_, lookup.len]);
-                if(callOption.isSome) {
-                    call = callOption.unwrap();
-                } 
-            }
-            else {
-              call = scheduled[i][1][index].unwrap().call.asInline;
-            }
+    for (var index in scheduled[i][1]) {
+      if (scheduled[i][1][index].isSome) {
+        let call;
+        if (scheduled[i][1][index].unwrap().call.isLookup) {
+          let lookup = scheduled[i][1][index].unwrap().call.asLookup;
+          let callOption = await api.query.preimage.preimageFor([lookup.hash_, lookup.len]);
+          if (callOption.isSome) {
+            call = callOption.unwrap();
+          }
+        } else {
+          call = scheduled[i][1][index].unwrap().call.asInline;
+        }
 
-            let extrinsic = (api.createType("GenericExtrinsicV4", call) as any).toHuman();
+        let extrinsic = (api.createType("GenericExtrinsicV4", call) as any).toHuman();
 
-            if (extrinsic.method.method == "newAuction" && extrinsic.method.section == "auctions") {
-                let key = scheduled[i][0];
-                let sliced = key.slice(-4);
+        if (extrinsic.method.method == "newAuction" && extrinsic.method.section == "auctions") {
+          let key = scheduled[i][0];
+          let sliced = key.slice(-4);
 
-                auctionMap.set(u8aToBn(sliced, {isLe: true}), {
-                    duration: extrinsic.method.args.duration.replace(/,/g, ''),
-                    lease_period: extrinsic.method.args.lease_period_index
-                  }
-                )
-            }
+          auctionMap.set(u8aToBn(sliced, { isLe: true }), {
+            duration: extrinsic.method.args.duration.replace(/,/g, ""),
+            lease_period: extrinsic.method.args.lease_period_index,
+          });
         }
       }
     }
+  }
 
-    let sortedKeys = [...auctionMap.keys()].sort();
+  let sortedKeys = [...auctionMap.keys()].sort();
 
-    let currentAuctionIndex = await api.query.auctions.auctionCounter();
-    let leasePeriod = await api.consts.slots.leasePeriod;
-    let leaseOffset = await api.consts.slots.leaseOffset;
+  let currentAuctionIndex = await api.query.auctions.auctionCounter();
+  let leasePeriod = await api.consts.slots.leasePeriod;
+  let leaseOffset = await api.consts.slots.leaseOffset;
 
-    let endingPeriod = await api.consts.auctions.endingPeriod
+  let endingPeriod = await api.consts.auctions.endingPeriod;
 
-    let currentLeasePeriod = await calculateCurrentLeasePeriod(api, leasePeriod, leaseOffset)
+  let currentLeasePeriod = await calculateCurrentLeasePeriod(api, leasePeriod, leaseOffset);
 
-    for(var index in sortedKeys) {
-        let nextAuction = auctionMap.get(sortedKeys[index])
+  for (var index in sortedKeys) {
+    let nextAuction = auctionMap.get(sortedKeys[index]);
 
-        let [auctionStartTimestamp, auctionStartDate] = await calculateTimestamp(api, Number(sortedKeys[index].toString()))
+    let [auctionStartTimestamp, auctionStartDate] = await calculateTimestamp(
+      api,
+      Number(sortedKeys[index].toString())
+    );
 
-        let slotsLeasedlready = argv.para == undefined ? undefined : await api.query.slots.leases(argv.para);
+    let slotsLeasedlready =
+      argv.para == undefined ? undefined : await api.query.slots.leases(argv.para);
 
-        console.log("Auction number %s will happen at block %s, timestamp %s, date %s", Number(currentAuctionIndex) + Number(index) + Number(1), sortedKeys[index], auctionStartTimestamp, auctionStartDate);
-        console.log("It will have a duration of %s blocks for lease period %s", nextAuction.duration, nextAuction.lease_period);
+    console.log(
+      "Auction number %s will happen at block %s, timestamp %s, date %s",
+      Number(currentAuctionIndex) + Number(index) + Number(1),
+      sortedKeys[index],
+      auctionStartTimestamp,
+      auctionStartDate
+    );
+    console.log(
+      "It will have a duration of %s blocks for lease period %s",
+      nextAuction.duration,
+      nextAuction.lease_period
+    );
 
-        let candleBeginBlock = Number(sortedKeys[index].toString()) + Number(nextAuction.duration);
+    let candleBeginBlock = Number(sortedKeys[index].toString()) + Number(nextAuction.duration);
 
-        let [candleStartTimestamp, candleStartDate] = await calculateTimestamp(api, candleBeginBlock)
+    let [candleStartTimestamp, candleStartDate] = await calculateTimestamp(api, candleBeginBlock);
 
-        console.log("Candle will happen at block %s, timestamp %s, date %s", candleBeginBlock, candleStartTimestamp, candleStartDate);
+    console.log(
+      "Candle will happen at block %s, timestamp %s, date %s",
+      candleBeginBlock,
+      candleStartTimestamp,
+      candleStartDate
+    );
 
-        let biddingEndBlock = Number(sortedKeys[index].toString()) + Number(nextAuction.duration) + Number(endingPeriod.toString());
+    let biddingEndBlock =
+      Number(sortedKeys[index].toString()) +
+      Number(nextAuction.duration) +
+      Number(endingPeriod.toString());
 
-        let [biddingEndTimestamp, biddingDate] = await calculateTimestamp(api, biddingEndBlock)
+    let [biddingEndTimestamp, biddingDate] = await calculateTimestamp(api, biddingEndBlock);
 
-        console.log("Bidding end will happen at block %s, timestamp %s, date %s", biddingEndBlock, biddingEndTimestamp, biddingDate);
+    console.log(
+      "Bidding end will happen at block %s, timestamp %s, date %s",
+      biddingEndBlock,
+      biddingEndTimestamp,
+      biddingDate
+    );
 
-        let yourLeaseStartSlot = slotsLeasedlready == undefined ? nextAuction.lease_period: currentLeasePeriod + (slotsLeasedlready as any).length
-        let leasePeriodPerSlot = await api.consts.auctions.leasePeriodsPerSlot;
-        let yourLeaseEndSlot = Number(nextAuction.lease_period) + Number(leasePeriodPerSlot.toString()) -1;
+    let yourLeaseStartSlot =
+      slotsLeasedlready == undefined
+        ? nextAuction.lease_period
+        : currentLeasePeriod + (slotsLeasedlready as any).length;
+    let leasePeriodPerSlot = await api.consts.auctions.leasePeriodsPerSlot;
+    let yourLeaseEndSlot =
+      Number(nextAuction.lease_period) + Number(leasePeriodPerSlot.toString()) - 1;
 
-        let lease_start_block = (new BN(nextAuction.lease_period.toString()).mul(u8aToBn(leasePeriod.toU8a()))).add(u8aToBn(leaseOffset.toU8a()));
-        let [leaseStartimestamp, leaseStartDate] = await calculateTimestamp(api, Number(lease_start_block.toString()))
+    let lease_start_block = new BN(nextAuction.lease_period.toString())
+      .mul(u8aToBn(leasePeriod.toU8a()))
+      .add(u8aToBn(leaseOffset.toU8a()));
+    let [leaseStartimestamp, leaseStartDate] = await calculateTimestamp(
+      api,
+      Number(lease_start_block.toString())
+    );
 
-        console.log("The new lease will start at block %s, timestamp %s, date %s", lease_start_block.toString(), leaseStartimestamp, leaseStartDate);
+    console.log(
+      "The new lease will start at block %s, timestamp %s, date %s",
+      lease_start_block.toString(),
+      leaseStartimestamp,
+      leaseStartDate
+    );
 
-        let lease_end_block = Number(lease_start_block.toString())  + (Number(leasePeriodPerSlot.toString())* Number(leasePeriod.toString()));
-        let [leaseEndtimestamp, leaseEndDate] = await calculateTimestamp(api, Number(lease_end_block.toString()))
+    let lease_end_block =
+      Number(lease_start_block.toString()) +
+      Number(leasePeriodPerSlot.toString()) * Number(leasePeriod.toString());
+    let [leaseEndtimestamp, leaseEndDate] = await calculateTimestamp(
+      api,
+      Number(lease_end_block.toString())
+    );
 
-        console.log("The new lease will end at block %s, timestamp %s, date %s", lease_end_block.toString(), leaseEndtimestamp, leaseEndDate);
+    console.log(
+      "The new lease will end at block %s, timestamp %s, date %s",
+      lease_end_block.toString(),
+      leaseEndtimestamp,
+      leaseEndDate
+    );
 
-        console.log("For this auction you need to bid from %s to %s", Math.floor(yourLeaseStartSlot).toString(), yourLeaseEndSlot.toString());
-
-    }
+    console.log(
+      "For this auction you need to bid from %s to %s",
+      Math.floor(yourLeaseStartSlot).toString(),
+      yourLeaseEndSlot.toString()
+    );
+  }
 
   await api.disconnect();
 };

--- a/src/tools/clear-local-assets-storage.ts
+++ b/src/tools/clear-local-assets-storage.ts
@@ -1,0 +1,86 @@
+/*
+  Clears the unused storage of pallet LocalAssets removed in runtime 2800
+
+Ex: ./node_modules/.bin/ts-node-transpile-only src/tools/clear-local-assets-storage.ts \
+   --url ws://localhost:9944 \
+   --max-assets 10 \
+   --limit 1000 \
+   --account-priv-key <key> \
+*/
+import yargs from "yargs";
+import "@polkadot/api-augment";
+import "@moonbeam-network/api-augment";
+import { Keyring } from "@polkadot/api";
+import { KeyringPair } from "@polkadot/keyring/types";
+import { getApiFor, NETWORK_YARGS_OPTIONS } from "../utils/networks";
+import { monitorSubmittedExtrinsic, waitForAllMonitoredExtrinsics } from "../utils/monitoring";
+import { ALITH_PRIVATE_KEY } from "../utils/constants";
+
+const argv = yargs(process.argv.slice(2))
+  .usage("Usage: $0")
+  .version("1.0.0")
+  .options({
+    ...NETWORK_YARGS_OPTIONS,
+    "account-priv-key": {
+      type: "string",
+      demandOption: false,
+      alias: "account",
+    },
+    "max-assets": {
+      type: "number",
+      default: 1,
+      describe: "The maximum number of assets to be removed by this call",
+    },
+    limit: {
+      type: "number",
+      default: 100,
+      describe: "The maximum number of storage entries to be removed by this call",
+    },
+    alith: {
+      type: "boolean",
+      demandOption: false,
+      conflicts: ["account-priv-key"],
+    },
+  })
+  .check((argv) => {
+    if (!(argv["account-priv-key"] || argv["alith"])) {
+      throw new Error("Missing --account-priv-key or --alith");
+    }
+    return true;
+  }).argv;
+
+async function main() {
+  const api = await getApiFor(argv);
+  const keyring = new Keyring({ type: "ethereum" });
+
+  try {
+    const max_assets = argv["max-assets"];
+    const entries_to_remove = argv["limit"];
+
+    let account: KeyringPair;
+    let nonce;
+    const privKey = argv["alith"] ? ALITH_PRIVATE_KEY : argv["account-priv-key"];
+    if (privKey) {
+      account = keyring.addFromUri(privKey, null, "ethereum");
+      const { nonce: rawNonce, data: balance } = (await api.query.system.account(
+        account.address
+      ));
+      nonce = BigInt(rawNonce.toString());
+    }
+
+    const isMigrationCompleted = (await api.query["moonbeamLazyMigrations"].localAssetsMigrationCompleted()).toPrimitive();
+    const isMigrationComplete2 = (await api.query.state.localAssetsMigrationCompleted()).toPrimitive();
+    console.log(isMigrationCompleted)
+    if (isMigrationCompleted) {
+      throw new Error("Migration completed, all keys have been removed!")
+    }
+
+    const extrinsicCall = api.tx["moonbeamLazyMigrations"].clearLocalAssetsStorage(max_assets, entries_to_remove)
+    await extrinsicCall.signAndSend(account, { nonce: nonce++ }, monitorSubmittedExtrinsic(api, { id: "migration" }));
+  } finally {
+    await waitForAllMonitoredExtrinsics();
+    await api.disconnect();
+  }
+}
+
+main().catch((err) => console.error("ERR!", err));

--- a/src/tools/export-state.ts
+++ b/src/tools/export-state.ts
@@ -99,7 +99,8 @@ async function main() {
             if (line.key.startsWith(storagePrefix)) {
               storageCount[storagePrefix] += 1n;
               storageKeySize[storagePrefix] = line.key.length / 2 - 1;
-              storageSize[storagePrefix] += BigInt(line.key.length / 2) + BigInt(line.value.length / 2) - 2n;
+              storageSize[storagePrefix] +=
+                BigInt(line.key.length / 2) + BigInt(line.value.length / 2) - 2n;
             }
           }
         }

--- a/src/tools/run-moonbeam-fork.ts
+++ b/src/tools/run-moonbeam-fork.ts
@@ -444,9 +444,15 @@ const main = async () => {
           ],
         ],
       ];
-      if (relayChainSpec.genesis?.runtimeGenesis && "patch" in relayChainSpec.genesis?.runtimeGenesis) {
+      if (
+        relayChainSpec.genesis?.runtimeGenesis &&
+        "patch" in relayChainSpec.genesis?.runtimeGenesis
+      ) {
         relayChainSpec.genesis.runtimeGenesis.patch.paras = paras;
-      } else if (relayChainSpec.genesis?.runtime && "runtime_genesis_config" in relayChainSpec.genesis?.runtime) {
+      } else if (
+        relayChainSpec.genesis?.runtime &&
+        "runtime_genesis_config" in relayChainSpec.genesis?.runtime
+      ) {
         relayChainSpec.genesis.runtime.runtime_genesis_config.paras = paras;
       } else if (relayChainSpec.genesis?.runtime && "paras" in relayChainSpec.genesis?.runtime) {
         relayChainSpec.genesis.runtime.paras = paras;

--- a/src/tools/search-account-transactions.ts
+++ b/src/tools/search-account-transactions.ts
@@ -3,7 +3,6 @@ import fs from "fs";
 
 import { exploreBlockRange, getApiFor, NETWORK_YARGS_OPTIONS, reverseBlocks } from "..";
 
-
 const argv = yargs(process.argv.slice(2))
   .usage("Usage: $0")
   .version("1.0.0")
@@ -15,7 +14,7 @@ const argv = yargs(process.argv.slice(2))
     },
     address: {
       type: "string",
-      description: "address to search transaction for"
+      description: "address to search transaction for",
     },
   }).argv;
 
@@ -26,29 +25,24 @@ const main = async () => {
     process.exit(1);
   }
 
-  const from = argv.from
-    || (await api.rpc.chain.getBlock()).block.header.number.toNumber()
+  const from = argv.from || (await api.rpc.chain.getBlock()).block.header.number.toNumber();
 
-  await reverseBlocks(
-    api,
-    { from: from, concurrency: 50 },
-    async (blockDetails) => {
-      if (blockDetails.block.header.number.toNumber() % 1000 == 0) {
-        console.log(`${blockDetails.block.header.number.toNumber()}...`);
-      }
-
-      const extrinsics = blockDetails.block.extrinsics.filter(
-        (e) => e.signer.toString().toLocaleLowerCase() == argv.address.toLocaleLowerCase()
-      );
-
-      if (extrinsics.length > 0) {
-        console.log(`[${blockDetails.block.header.number.toNumber().toString().padStart(9, ' ')}`);
-        extrinsics.map(e => {
-          console.log(`  --`, e.toHuman());
-        })
-      }
+  await reverseBlocks(api, { from: from, concurrency: 50 }, async (blockDetails) => {
+    if (blockDetails.block.header.number.toNumber() % 1000 == 0) {
+      console.log(`${blockDetails.block.header.number.toNumber()}...`);
     }
-  );
+
+    const extrinsics = blockDetails.block.extrinsics.filter(
+      (e) => e.signer.toString().toLocaleLowerCase() == argv.address.toLocaleLowerCase()
+    );
+
+    if (extrinsics.length > 0) {
+      console.log(`[${blockDetails.block.header.number.toNumber().toString().padStart(9, " ")}`);
+      extrinsics.map((e) => {
+        console.log(`  --`, e.toHuman());
+      });
+    }
+  });
 };
 
 main();

--- a/src/tools/send-clear-origin-messages-from-relay.ts
+++ b/src/tools/send-clear-origin-messages-from-relay.ts
@@ -5,7 +5,17 @@ import { Keyring } from "@polkadot/api";
 import { getApiFor } from "../utils/networks";
 import { getAccountIdentity } from "../utils/monitoring";
 import { BN } from "@polkadot/util";
-import { isBigInt, isBn, isHex, isNumber, isU8a, u8aConcat, u8aToBn, u8aToHex, u8aToU8a } from '@polkadot/util';
+import {
+  isBigInt,
+  isBn,
+  isHex,
+  isNumber,
+  isU8a,
+  u8aConcat,
+  u8aToBn,
+  u8aToHex,
+  u8aToU8a,
+} from "@polkadot/util";
 
 const argv = yargs(process.argv.slice(2))
   .usage("Usage: $0")
@@ -18,8 +28,8 @@ const argv = yargs(process.argv.slice(2))
       demandOption: true,
     },
     para: {
-        type: "number",
-        description: "ParaId to which the messages are sent",
+      type: "number",
+      description: "ParaId to which the messages are sent",
     },
     numMessages: {
       type: "number",
@@ -31,31 +41,27 @@ const argv = yargs(process.argv.slice(2))
     },
   }).argv;
 
-
 const main = async () => {
   const api = await getApiFor(argv);
 
   let sendExtrinsic = api.tx.xcmPallet.send(
-    { V2: { parents: new BN(0), interior: { X1: { Parachain: argv.para }} } },
+    { V2: { parents: new BN(0), interior: { X1: { Parachain: argv.para } } } },
     {
-      V2: [
-        { ClearOrigin: null }
-      ]
+      V2: [{ ClearOrigin: null }],
     }
   );
   let Txs = [];
 
   // If several calls, we just push alltogether to batch
   for (let i = 0; i < argv.numMessages; i++) {
-    Txs.push(sendExtrinsic)
+    Txs.push(sendExtrinsic);
   }
-
 
   const batchCall = api.tx.utility.batchAll(Txs);
   let account;
   let nonce;
   [account, nonce] = await accountWrapper(api, argv.privKey);
-  console.log(account )
+  console.log(account);
   await api.tx(batchCall.toHex()).signAndSend(account);
 
   await api.disconnect();
@@ -76,7 +82,7 @@ async function accountWrapper(api, privateKey) {
 
   // Create account and get nonce
   let account = await keyring.addFromUri(privateKey, null, "sr25519");
-  console.log(account.address)
+  console.log(account.address);
   const { nonce: rawNonce } = (await api.query.system.account(account.address)) as any;
   let nonce = BigInt(rawNonce.toString());
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,4 +1,4 @@
-import type { ProviderInterface } from '@polkadot/rpc-provider/types';
+import type { ProviderInterface } from "@polkadot/rpc-provider/types";
 import { promiseConcurrent } from "./functions";
 
 const debug = require("debug")("utils:storage-query");
@@ -27,12 +27,18 @@ const startReport = (total: () => number) => {
 };
 
 export function splitPrefix(prefix: string, splitDepth) {
-  return new Array(256 ** splitDepth).fill(0).map((_, i) => `${prefix}${i.toString(16).padStart(splitDepth * 2, "0")}`);
+  return new Array(256 ** splitDepth)
+    .fill(0)
+    .map((_, i) => `${prefix}${i.toString(16).padStart(splitDepth * 2, "0")}`);
 }
 
 // Only works with keys longer than keyPrefix
 // Is effective only on well spread keys
-export async function concurrentGetKeys(provider: ProviderInterface, keyPrefix: string, blockHash: string) {
+export async function concurrentGetKeys(
+  provider: ProviderInterface,
+  keyPrefix: string,
+  blockHash: string
+) {
   const maxKeys = 1000;
   let total = 0;
 
@@ -88,10 +94,15 @@ export async function queryUnorderedRawStorage(
   }));
 }
 
-
 export async function processAllStorage(
   provider: ProviderInterface,
-  options: { prefix: string, blockHash: string, splitDepth?: number, concurrency?: number, delayMS?: number },
+  options: {
+    prefix: string;
+    blockHash: string;
+    splitDepth?: number;
+    concurrency?: number;
+    delayMS?: number;
+  },
   processor: (batchResult: { key: `0x${string}`; value: string }[]) => void
 ) {
   const { prefix, blockHash, splitDepth, concurrency, delayMS } = options;
@@ -116,10 +127,7 @@ export async function processAllStorage(
           if (keys.length == 0) {
             break;
           }
-          const response = await provider.send("state_queryStorageAt", [
-            keys,
-            blockHash,
-          ]);
+          const response = await provider.send("state_queryStorageAt", [keys, blockHash]);
 
           if (!response[0]) {
             throw new Error(`No response: ${JSON.stringify(response)}`);
@@ -134,7 +142,7 @@ export async function processAllStorage(
           startKey = keys[keys.length - 1];
 
           if (delayMS) {
-            await new Promise(resolve => setTimeout(resolve, delayMS));
+            await new Promise((resolve) => setTimeout(resolve, delayMS));
           }
         }
       },


### PR DESCRIPTION
This change adds a new script for clearing the storage previously used by LocalAssets pallet.

I have tested the lazy migration with chopsticks against the moonbeam stake. It has around `~9000` storage entries.