### PR TITLE
Adds Support for Legacy and Inline Ref Types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moonbeam-tools",
-  "version": "0.0.47",
+  "version": "0.0.49",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "moonbeam-tools",
-      "version": "0.0.47",
+      "version": "0.0.49",
       "license": "GPL-3.0",
       "dependencies": {
         "@moonbeam-network/api-augment": "^0.2302.0",


### PR DESCRIPTION
A user was trying to use the tool with an `Inline` Referendum type and did not support it.

These modifications allows for both `Inline` and also `Legacy`.

Tested it with chopsticks and all three referendum types.