### PR TITLE
Add test for fun

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-/test
 /bins
 /build
 /dist

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,3 +19,18 @@ jobs:
           node-version: 20.x
       - name: Check with Prettier
         run: npx prettier --check --ignore-path .prettierignore '**/*.(yml|js|ts)'
+
+  test:
+    name: "Run Tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/verify-compilation.yml
+++ b/.github/workflows/verify-compilation.yml
@@ -20,3 +20,18 @@ jobs:
 
       - name: Verify TypeScript compilation
         run: npm run build
+
+  test:
+    name: "Run Tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm test

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 /scripts
-/test
 /bins
 /build
 /docker

--- a/src/tools/monitor.ts
+++ b/src/tools/monitor.ts
@@ -26,6 +26,11 @@ const argv = yargs(process.argv.slice(2))
       default: false,
       description: "listen to finalized only",
     },
+    blocks: {
+      type: "number",
+      description: "Number of blocks to monitor",
+      default: Infinity,
+    },
   })
   .check(function (argv) {
     if (!argv.url && !argv.networks) {
@@ -36,7 +41,7 @@ const argv = yargs(process.argv.slice(2))
 
 const main = async () => {
   if (argv.networks) {
-    argv.networks.map((network) => getMonitoredApiFor({ network, finalized: argv.finalized }));
+    argv.networks.map((network) => getMonitoredApiFor({ network, finalized: argv.finalized, blocks: argv.blocks }));
   } else {
     getMonitoredApiFor(argv);
   }

--- a/src/utils/monitoring.ts
+++ b/src/utils/monitoring.ts
@@ -376,8 +376,10 @@ export const listenBlocks = async (
   api: ApiPromise,
   finalized: boolean,
   callBack: (blockDetails: RealtimeBlockDetails) => Promise<void>,
+  blocksToMonitor: number = Infinity
 ) => {
   let latestBlockTime = 0;
+  let blockCount = 0;
   try {
     latestBlockTime = (
       await api.query.timestamp.now.at((await api.rpc.chain.getBlock()).block.header.parentHash)
@@ -398,6 +400,10 @@ export const listenBlocks = async (
       elapsedMilliSecs: blockDetails.blockTime - latestBlockTime,
     });
     latestBlockTime = blockDetails.blockTime;
+    blockCount++;
+    if (blockCount >= blocksToMonitor) {
+      unsubHeads();
+    }
   });
   return unsubHeads;
 };

--- a/test/monitor.test.ts
+++ b/test/monitor.test.ts
@@ -1,0 +1,12 @@
+import { exec } from 'child_process';
+
+describe('Monitor Script', () => {
+  test('should run without errors', (done) => {
+    exec('node dist/monitor.cjs --networks moonriver', (error, stdout, stderr) => {
+      expect(error).toBeNull();
+      expect(stderr).toBe('');
+      expect(stdout).toContain('Monitoring');
+      done();
+    });
+  });
+});

--- a/test/sample.test.ts
+++ b/test/sample.test.ts
@@ -1,0 +1,7 @@
+import { sum } from '../src/utils/functions';
+
+describe('Sample Test', () => {
+  test('adds 1 + 2 to equal 3', () => {
+    expect(sum(1, 2)).toBe(3);
+  });
+});


### PR DESCRIPTION
Add tests and update monitor script to support block monitoring parameter.

* Add `test/sample.test.ts` with a sample test case using Jest.
* Add `test/monitor.test.ts` with a test case for the monitor script using Jest.
* Modify `.github/workflows/check.yml` and `.github/workflows/verify-compilation.yml` to include jobs to run tests using Jest.
* Modify `.dockerignore` and `.npmignore` to ensure the `test` directory is not excluded.
* Modify `src/tools/monitor.ts` to add a new feature to the monitor script that uses a parameter to specify the number of blocks to monitor until it stops.
* Modify `src/utils/monitoring.ts` to update the `listenBlocks` function to support the new parameter as optional.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Moonsong-Labs/moonbeam-tools?shareId=cb47eb63-7dad-4c8b-ba59-38c7ac766473).